### PR TITLE
Bug fixes and minor refactoring

### DIFF
--- a/kubernetesclient/namespace_client.go
+++ b/kubernetesclient/namespace_client.go
@@ -6,12 +6,12 @@ import (
 	"github.com/rancher/kubernetes-model/model"
 )
 
-const NamespacePath string = "/api/v1/namespaces/%s/namespaces"
+const NamespacePath string = "/api/v1/namespaces/"
 const NamespaceByNamePath string = "/api/v1/namespaces/%s"
 
 type NamespaceOperations interface {
 	ByName(name string) (*model.Namespace, error)
-	CreateNamespace(namespace string, resource *model.Namespace) (*model.Namespace, error)
+	CreateNamespace(resource *model.Namespace) (*model.Namespace, error)
 	ReplaceNamespace(namespace string, resource *model.Namespace) (*model.Namespace, error)
 }
 
@@ -32,10 +32,9 @@ func (c *NamespaceClient) ByName(name string) (*model.Namespace, error) {
 	return resp, err
 }
 
-func (c *NamespaceClient) CreateNamespace(namespace string, resource *model.Namespace) (*model.Namespace, error) {
+func (c *NamespaceClient) CreateNamespace(resource *model.Namespace) (*model.Namespace, error) {
 	resp := &model.Namespace{}
-	path := fmt.Sprintf(NamespacePath, namespace)
-	err := c.client.doPost(path, resource, resp)
+	err := c.client.doPost(NamespacePath, resource, resp)
 	return resp, err
 }
 

--- a/main.go
+++ b/main.go
@@ -70,9 +70,8 @@ func launch(c *cli.Context) {
 
 	kClient := kubernetesclient.NewClient(conf.KubernetesURL, true)
 
-	rcHandler := kubernetesevents.NewHandler(rClient, kClient, kubernetesevents.RCKind)
 	svcHandler := kubernetesevents.NewHandler(rClient, kClient, kubernetesevents.ServiceKind)
-	handlers := []kubernetesevents.Handler{rcHandler, svcHandler}
+	handlers := []kubernetesevents.Handler{svcHandler}
 
 	go func(rc chan error) {
 		err := kubernetesevents.ConnectToEventStream(handlers, conf)

--- a/rancherevents/eventhandlers/ping_handler.go
+++ b/rancherevents/eventhandlers/ping_handler.go
@@ -1,0 +1,21 @@
+package eventhandlers
+
+import (
+	revents "github.com/rancher/go-machine-service/events"
+	"github.com/rancher/go-rancher/client"
+	util "github.com/rancher/kubernetes-agent/rancherevents/util"
+)
+
+type PingHandler struct {
+}
+
+func NewPingHandler() *PingHandler {
+	return &PingHandler{}
+}
+
+func (h *PingHandler) Handler(event *revents.Event, cli *client.RancherClient) error {
+	if err := util.CreateAndPublishReply(event, cli); err != nil {
+		return err
+	}
+	return nil
+}

--- a/rancherevents/eventhandlers/provide_lables_handler.go
+++ b/rancherevents/eventhandlers/provide_lables_handler.go
@@ -1,0 +1,121 @@
+package eventhandlers
+
+import (
+	log "github.com/Sirupsen/logrus"
+	"strings"
+
+	revents "github.com/rancher/go-machine-service/events"
+	"github.com/rancher/go-rancher/client"
+	"github.com/rancher/kubernetes-agent/kubernetesclient"
+	util "github.com/rancher/kubernetes-agent/rancherevents/util"
+)
+
+type syncHandler struct {
+	kClient *kubernetesclient.Client
+}
+
+func NewProvideLablesHandler(kClient *kubernetesclient.Client) *syncHandler {
+	return &syncHandler{
+		kClient: kClient,
+	}
+}
+
+func (h *syncHandler) Handler(event *revents.Event, cli *client.RancherClient) error {
+	log.Infof("Received event: Name: %s, Event Id: %s, Resource Id: %s", event.Name, event.Id, event.ResourceId)
+
+	namespace, name := h.getPod(event)
+	if namespace == "" || name == "" {
+		if err := util.CreateAndPublishReply(event, cli); err != nil {
+			return err
+		}
+		return nil
+	}
+
+	pod, err := h.kClient.Pod.ByName(namespace, name)
+	if err != nil {
+		log.Warnf("Error looking up pod: %#v", err)
+		if apiErr, ok := err.(*client.ApiError); ok && apiErr.StatusCode == 404 {
+			if err := util.CreateAndPublishReply(event, cli); err != nil {
+				return err
+			}
+			return nil
+		}
+		return err
+	}
+
+	/*
+	   Building this:
+	   {instancehostmap: {
+	       instance: {
+	           +data: {
+	               +fields: {
+	                 labels: {
+	*/
+	replyData := make(map[string]interface{})
+	ihm := make(map[string]interface{})
+	i := make(map[string]interface{})
+	data := make(map[string]interface{})
+	fields := make(map[string]interface{})
+	labels := make(map[string]string)
+
+	replyData["instanceHostMap"] = ihm
+	ihm["instance"] = i
+	i["+data"] = data
+	data["+fields"] = fields
+	fields["+labels"] = labels
+
+	for key, v := range pod.Metadata.Labels {
+		if val, ok := v.(string); ok {
+			labels[key] = val
+		}
+	}
+
+	labels["io.rancher.service.deployment.unit"] = pod.Metadata.Uid
+	labels["io.rancher.stack.name"] = pod.Metadata.Namespace
+
+	reply := util.NewReply(event)
+	reply.ResourceType = "instanceHostMap"
+	reply.ResourceId = event.ResourceId
+	reply.Data = replyData
+	log.Infof("Reply: %+v", reply)
+	err = util.PublishReply(reply, cli)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (h *syncHandler) getPod(event *revents.Event) (string, string) {
+	// TODO Rewrite this horror
+	data := event.Data
+	if ihm, ok := data["instanceHostMap"]; ok {
+		if ihmMap, ok := ihm.(map[string]interface{}); ok {
+			if i, ok := ihmMap["instance"]; ok {
+				if iMap, ok := i.(map[string]interface{}); ok {
+					if d, ok := iMap["data"]; ok {
+						if dMap, ok := d.(map[string]interface{}); ok {
+							if f, ok := dMap["fields"]; ok {
+								if fMap, ok := f.(map[string]interface{}); ok {
+									if labels, ok := fMap["labels"]; ok {
+										if lMap, ok := labels.(map[string]interface{}); ok {
+											if l, ok := lMap["io.kubernetes.pod.name"]; ok {
+												if label, ok := l.(string); ok {
+													parts := strings.SplitN(label, "/", 2)
+													if len(parts) == 2 {
+														return parts[0], parts[1]
+													}
+												}
+											}
+										}
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+
+	return "", ""
+}

--- a/rancherevents/listener.go
+++ b/rancherevents/listener.go
@@ -1,27 +1,20 @@
 package rancherevents
 
 import (
-	log "github.com/Sirupsen/logrus"
-	"strings"
-
 	revents "github.com/rancher/go-machine-service/events"
-	"github.com/rancher/go-rancher/client"
 	"github.com/rancher/kubernetes-agent/config"
 	"github.com/rancher/kubernetes-agent/kubernetesclient"
+	"github.com/rancher/kubernetes-agent/rancherevents/eventhandlers"
 )
 
 func ConnectToEventStream(conf config.Config) error {
 
 	kClient := kubernetesclient.NewClient(conf.KubernetesURL, false)
-	sh := syncHandler{
-		kClient: kClient,
-	}
-	ph := PingHandler{}
 
 	eventHandlers := map[string]revents.EventHandler{
-		"compute.instance.providelabels": sh.Handler,
-		"config.update":                  ph.Handler,
-		"ping":                           ph.Handler,
+		"compute.instance.providelabels": eventhandlers.NewProvideLablesHandler(kClient).Handler,
+		"config.update":                  eventhandlers.NewPingHandler().Handler,
+		"ping":                           eventhandlers.NewPingHandler().Handler,
 	}
 
 	router, err := revents.NewEventRouter("", 0, conf.CattleURL, conf.CattleAccessKey, conf.CattleSecretKey, nil, eventHandlers, "", conf.WorkerCount)
@@ -29,144 +22,5 @@ func ConnectToEventStream(conf config.Config) error {
 		return err
 	}
 	err = router.StartWithoutCreate(nil)
-	return err
-}
-
-type syncHandler struct {
-	kClient *kubernetesclient.Client
-}
-
-func (h *syncHandler) Handler(event *revents.Event, cli *client.RancherClient) error {
-	log.Infof("Received event: Name: %s, Event Id: %s, Resource Id: %s", event.Name, event.Id, event.ResourceId)
-
-	namespace, name := h.getPod(event)
-	if namespace == "" || name == "" {
-		reply := newReply(event)
-		reply.ResourceType = event.ResourceType
-		reply.ResourceId = event.ResourceId
-		err := publishReply(reply, cli)
-		if err != nil {
-			return err
-		}
-		return nil
-	}
-
-	pod, err := h.kClient.Pod.ByName(namespace, name)
-	if err != nil {
-		log.Warnf("Error looking up pod: %#v", err)
-		if apiErr, ok := err.(*client.ApiError); ok && apiErr.StatusCode == 404 {
-			reply := newReply(event)
-			reply.ResourceType = event.ResourceType
-			reply.ResourceId = event.ResourceId
-			err := publishReply(reply, cli)
-			if err != nil {
-				return err
-			}
-			return nil
-		}
-		return err
-	}
-
-	/*
-		  Building this:
-		  {instancehostmap: {
-			  instance: {
-				  +data: {
-					  +fields: {
-						labels: {
-	*/
-	replyData := make(map[string]interface{})
-	ihm := make(map[string]interface{})
-	i := make(map[string]interface{})
-	data := make(map[string]interface{})
-	fields := make(map[string]interface{})
-	labels := make(map[string]string)
-
-	replyData["instanceHostMap"] = ihm
-	ihm["instance"] = i
-	i["+data"] = data
-	data["+fields"] = fields
-	fields["+labels"] = labels
-
-	for key, v := range pod.Metadata.Labels {
-		if val, ok := v.(string); ok {
-			labels[key] = val
-		}
-	}
-
-	labels["io.rancher.service.deployment.unit"] = pod.Metadata.Uid
-	labels["io.rancher.stack.name"] = pod.Metadata.Namespace
-
-	reply := newReply(event)
-	reply.ResourceType = "instanceHostMap"
-	reply.ResourceId = event.ResourceId
-	reply.Data = replyData
-	log.Infof("Reply: %+v", reply)
-	err = publishReply(reply, cli)
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
-func (h *syncHandler) getPod(event *revents.Event) (string, string) {
-	// TODO Rewrite this horror
-	data := event.Data
-	if ihm, ok := data["instanceHostMap"]; ok {
-		if ihmMap, ok := ihm.(map[string]interface{}); ok {
-			if i, ok := ihmMap["instance"]; ok {
-				if iMap, ok := i.(map[string]interface{}); ok {
-					if d, ok := iMap["data"]; ok {
-						if dMap, ok := d.(map[string]interface{}); ok {
-							if f, ok := dMap["fields"]; ok {
-								if fMap, ok := f.(map[string]interface{}); ok {
-									if labels, ok := fMap["labels"]; ok {
-										if lMap, ok := labels.(map[string]interface{}); ok {
-											if l, ok := lMap["io.kubernetes.pod.name"]; ok {
-												if label, ok := l.(string); ok {
-													parts := strings.SplitN(label, "/", 2)
-													if len(parts) == 2 {
-														return parts[0], parts[1]
-													}
-												}
-											}
-										}
-									}
-								}
-							}
-						}
-					}
-				}
-			}
-		}
-	}
-
-	return "", ""
-}
-
-type PingHandler struct {
-}
-
-func (h *PingHandler) Handler(event *revents.Event, cli *client.RancherClient) error {
-	reply := newReply(event)
-	if reply.Name == "" {
-		return nil
-	}
-	err := publishReply(reply, cli)
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
-func newReply(event *revents.Event) *client.Publish {
-	return &client.Publish{
-		Name:        event.ReplyTo,
-		PreviousIds: []string{event.Id},
-	}
-}
-
-func publishReply(reply *client.Publish, apiClient *client.RancherClient) error {
-	_, err := apiClient.Publish.Create(reply)
 	return err
 }

--- a/rancherevents/listener_test.go
+++ b/rancherevents/listener_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/rancher/kubernetes-agent/config"
 	"github.com/rancher/kubernetes-agent/dockerclient"
 	"github.com/rancher/kubernetes-agent/kubernetesclient"
+	"github.com/rancher/kubernetes-agent/rancherevents/eventhandlers"
 )
 
 var conf = config.Config{
@@ -85,9 +86,7 @@ func (s *ListenerTestSuite) TestSyncHandler(c *check.C) {
 			},
 		},
 	}
-	sh := syncHandler{
-		kClient: s.kClient,
-	}
+	sh := eventhandlers.NewProvideLablesHandler(s.kClient)
 
 	err = sh.Handler(event, s.mockRClient)
 	if err != nil {

--- a/rancherevents/util/util.go
+++ b/rancherevents/util/util.go
@@ -1,0 +1,32 @@
+package eventhandlers
+
+import (
+	revents "github.com/rancher/go-machine-service/events"
+	"github.com/rancher/go-rancher/client"
+)
+
+func NewReply(event *revents.Event) *client.Publish {
+	return &client.Publish{
+		Name:         event.ReplyTo,
+		PreviousIds:  []string{event.Id},
+		ResourceType: event.ResourceType,
+		ResourceId:   event.ResourceId,
+	}
+}
+
+func PublishReply(reply *client.Publish, apiClient *client.RancherClient) error {
+	_, err := apiClient.Publish.Create(reply)
+	return err
+}
+
+func CreateAndPublishReply(event *revents.Event, cli *client.RancherClient) error {
+	reply := NewReply(event)
+	if reply.Name == "" {
+		return nil
+	}
+	err := PublishReply(reply, cli)
+	if err != nil {
+		return err
+	}
+	return nil
+}


### PR DESCRIPTION
The PF fixes the following:
- bug in createNamespace code
- segregates each rancher event handler type to its own file
- don't send updates to Rancher on k8s ReplicationController events
- set VIP (=clusterIp) on k8s service propagated to Rancher
