### PR TITLE
Set io.rancher.container.dns to false for pod containers

### DIFF
--- a/rancherevents/eventhandlers/provide_lables_handler.go
+++ b/rancherevents/eventhandlers/provide_lables_handler.go
@@ -41,6 +41,7 @@ func (h *syncHandler) Handler(event *events.Event, cli *client.RancherClient) er
 	}
 
 	labels["io.rancher.service.deployment.unit"] = containerLabels["io.kubernetes.pod.uid"]
+	labels["io.rancher.container.dns"] = "false"
 	labels["io.rancher.stack.name"] = namespace
 
 	if isPodContainer(containerLabels) {


### PR DESCRIPTION
Set io.rancher.container.dns to false for pod containers

/etc/resolv.conf nameserver gets set to cluster-dns value anyway