### PR TITLE
WIP: Handle host evacuate/drain 

### DIFF
--- a/hostwatch/hostwatch.go
+++ b/hostwatch/hostwatch.go
@@ -23,6 +23,8 @@ const (
 	ActivatingState = "activating"
 	// DeactivatingState specifies the default value of deactivating state of host in Ranceher Metadata
 	DeactivatingState = "deactivating"
+	// EvacuatingState specifies the default value of evacuating state of host in Ranceher Metadata
+	EvacuatingState = "evacuating"
 )
 
 type hostSyncer struct {

--- a/hostwatch/status_syncer.go
+++ b/hostwatch/status_syncer.go
@@ -1,13 +1,22 @@
 package hostwatch
 
 import (
+	"fmt"
+
 	log "github.com/Sirupsen/logrus"
 	"github.com/rancher/go-rancher-metadata/metadata"
+	"github.com/rancher/kubectld/cli"
 	"github.com/rancher/kubernetes-agent/kubernetesclient"
 )
 
 var (
 	maxRetryCount int = 3
+)
+
+const (
+	DrainLabelName   = "io.rancher.host.state"
+	DrainLabelValue  = "evacuated"
+	DrainSyncTimeout = "120s"
 )
 
 func statusSync(kClient *kubernetesclient.Client, metadataClient metadata.Client) {
@@ -23,6 +32,8 @@ func statusSync(kClient *kubernetesclient.Client, metadataClient metadata.Client
 			cordonUncordon(host, kClient, metadataClient, false)
 		case DeactivatingState:
 			cordonUncordon(host, kClient, metadataClient, true)
+		case EvacuatingState:
+			drain(host, kClient)
 		}
 	}
 }
@@ -40,6 +51,7 @@ func cordonUncordon(host metadata.Host, kClient *kubernetesclient.Client, metada
 			break
 		}
 		node.Spec.Unschedulable = unschedulable
+		delete(node.ObjectMeta.Labels, DrainLabelName)
 		_, err = kClient.Node.ReplaceNode(node)
 		if err != nil {
 			log.Errorf("Error updating node [%s] with new schedulable state, err :[%v]", host.Hostname, err)
@@ -51,4 +63,51 @@ func cordonUncordon(host metadata.Host, kClient *kubernetesclient.Client, metada
 	if !changed {
 		log.Errorf("Failed to cordon/uncordon node: [%s]", host.Hostname)
 	}
+}
+
+func drain(host metadata.Host, kClient *kubernetesclient.Client) {
+	node, err := kClient.Node.ByName(host.Hostname)
+	if err != nil {
+		log.Errorf("Error getting node: [%s] by name from kubernetes, err: [%v]", host.Hostname, err)
+		return
+	}
+	if state, ok := node.ObjectMeta.Labels[DrainLabelName]; !ok || (state != DrainLabelValue) {
+		err = execDrainCmd(host.Hostname)
+		if err != nil {
+			log.Errorf("Error draining node: [%s], err: [%v]", host.Hostname, err)
+			return
+		}
+		node, err = kClient.Node.ByName(host.Hostname)
+		if err != nil {
+			log.Errorf("Error getting node: [%s] by name from kubernetes, err: [%v]", host.Hostname, err)
+			return
+		}
+		node.ObjectMeta.Labels[DrainLabelName] = DrainLabelValue
+		_, err = kClient.Node.ReplaceNode(node)
+		if err != nil {
+			log.Errorf("Error updating node [%s] with new label, err :[%v]", host.Hostname, err)
+			return
+		}
+	}
+}
+
+func execDrainCmd(hostname string) error {
+	cmd := "kubectl"
+	args := []string{
+		"drain",
+		hostname,
+		"--ignore-daemonsets",
+		"--force",
+		"--delete-local-data",
+		"--timeout",
+		DrainSyncTimeout}
+	output := cli.Execute(cmd, args...)
+	if output.ExitCode > 0 {
+		return fmt.Errorf("%s", output.StdErr)
+	}
+	if output.Err != nil {
+		return fmt.Errorf("%s", output.Err)
+	}
+	fmt.Printf("%s", output.StdOut)
+	return nil
 }

--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -1,6 +1,8 @@
 FROM rancher/agent-base:v0.3.0
 RUN apt-get update -y && \
     apt-get -yy -q install ca-certificates wget unzip
+RUN wget -O /usr/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/v1.7.4/bin/linux/amd64/kubectl && \
+    chmod +x /usr/bin/kubectl
 ENV SSL_SCRIPT_COMMIT 98660ada3d800f653fc1f105771b5173f9d1a019
 RUN wget -O /usr/bin/update-rancher-ssl https://raw.githubusercontent.com/rancher/rancher/${SSL_SCRIPT_COMMIT}/server/bin/update-rancher-ssl && \
     chmod +x /usr/bin/update-rancher-ssl

--- a/rancherevents/listener.go
+++ b/rancherevents/listener.go
@@ -15,6 +15,7 @@ func ConnectToEventStream(rClient *client.RancherClient, kClient *kubernetesclie
 		"ping":            eventhandlers.NewPingHandler().Handler,
 		"host.deactivate": eventhandlers.NewHostHandler(kClient).Handler,
 		"host.activate":   eventhandlers.NewHostHandler(kClient).Handler,
+		"host.evacuate":   eventhandlers.NewHostHandler(kClient).Handler,
 	}
 
 	router, err := revents.NewEventRouter(rClient, conf.WorkerCount, eventHandlers)

--- a/scripts/test
+++ b/scripts/test
@@ -93,6 +93,8 @@ users:
     token: "test"
 EOF
 
+cp /bin/true /bin/kubectl
+
 for pkg in $(go list ./...); do
     if [[ $pkg != *"vendor"* ]]; then
         go test -v $pkg

--- a/trash.conf
+++ b/trash.conf
@@ -11,3 +11,4 @@ github.com/pkg/errors v0.7.0
 k8s.io/client-go v4.0.0 transitive=true
 github.com/docker/distribution 3da015f8aaa8653690917031108bd45a2bed5cfa
 github.com/opencontainers/go-digest v1.0.0-rc1
+github.com/rancher/kubectld/cli af773c87d5607f5bdb65a6c36d459c64e865c963

--- a/vendor/github.com/rancher/kubectld/cli/cli.go
+++ b/vendor/github.com/rancher/kubectld/cli/cli.go
@@ -1,0 +1,46 @@
+package cli
+
+import (
+	"bytes"
+	"os/exec"
+	"syscall"
+)
+
+type ErrExec struct {
+	Output Output
+}
+
+func (e *ErrExec) Error() string {
+	return e.Output.StdErr
+}
+
+type Output struct {
+	ExitCode int         `json:"exitCode"`
+	StdOut   string      `json:"stdOut"`
+	StdErr   string      `json:"stdErr"`
+	Err      error       `json:"error"`
+	Data     interface{} `json:"data"`
+}
+
+func Execute(cmd string, args ...string) Output {
+	var outStream bytes.Buffer
+	var errStream bytes.Buffer
+
+	c := exec.Command(cmd, args...)
+	c.Stdin = nil
+	c.Stdout = &outStream
+	c.Stderr = &errStream
+
+	output := Output{}
+	output.Err = c.Run()
+	output.StdOut = string(outStream.Bytes())
+	output.StdErr = string(errStream.Bytes())
+
+	if exitErr, ok := output.Err.(*exec.ExitError); ok {
+		if waitStatus, ok := exitErr.Sys().(syscall.WaitStatus); ok {
+			output.ExitCode = waitStatus.ExitStatus()
+		}
+	}
+
+	return output
+}


### PR DESCRIPTION
The PR summary:

- Add evacuation handling so that when evacuate is pressed it will run `kubectl drain` command with the following option:
   - `--force`: which should remove pods that are not controlled using a controller (deployment, rc, etc.)
   - `--timeout`: which will add 120 seconds for the drain command to succeed
   - `--ignore-daemonsets`: which will ignore pods run by daemonsets
   - `--delete-local-data`: which will delete pods with empty dir volumes

- Add the `io.rancher.host.state=evacuated` to the host that is being drained successfully.

- Remove this label in the host activation handler.

- The evacuation event handler will wait until it can verify that the label is correctly exists on the host.

Notes:

- since single pods are being deleted using --force, the kubernetes agent will be removed as will, which may interrupt its own host evacuation for a while.
- since single pods scheduling is being handled by cattle, evacuating single pods result in scheduling the pods on the same host again.
